### PR TITLE
Removed hyphen in *.service filename and executed directly

### DIFF
--- a/autostart/systemd/README.md
+++ b/autostart/systemd/README.md
@@ -1,29 +1,34 @@
-# Install CarConnectivity-MQTT as a service on on operating systems providing systemd
+# Install carconnectivitymqtt as a service on on operating systems providing systemd
 
 ## How to install
-Open file carconnectivity-mqtt.service and change the username and commandline parameters according to your needs
+Open file carconnectivitymqtt.service and change the username and commandline parameters according to your needs
 
 Copy the unit file to /etc/systemd/system and give it permissions:
 ```bash
-sudo cp carconnectivity-mqtt.service /etc/systemd/system/carconnectivity-mqtt.service
-sudo chmod 644 /etc/systemd/system/carconnectivity-mqtt.service
+sudo cp carconnectivitymqtt.service /etc/systemd/system/carconnectivitymqtt.service
+sudo chmod 644 /etc/systemd/system/carconnectivitymqtt.service
+```
+
+## Reload daemons
+```
+sudo systemctl daemon-reload
 ```
 
 ## How to start
 Once you have installed the file, you are ready to test the service:
 ```bash
-sudo systemctl start carconnectivity-mqtt
-sudo systemctl status carconnectivity-mqtt
+sudo systemctl start carconnectivitymqtt
+sudo systemctl status carconnectivitymqtt
 ```
 
 The service can be stopped or restarted using standard systemd commands:
 ```bash
-sudo systemctl stop carconnectivity-mqtt
-sudo systemctl restart carconnectivity-mqtt
+sudo systemctl stop carconnectivitymqtt
+sudo systemctl restart carconnectivitymqtt
 ```
 
 ## How to enable autostart after boot
 Finally, use the enable command to ensure that the service starts whenever the system boots:
 ```bash
-sudo systemctl enable carconnectivity-mqtt
+sudo systemctl enable carconnectivitymqtt
 ```

--- a/autostart/systemd/carconnectivitymqtt.service
+++ b/autostart/systemd/carconnectivitymqtt.service
@@ -6,7 +6,7 @@ After=network-online.target
 Type=simple
 # change the username and commandline parameters here:
 User=yourunixusername
-ExecStart=/usr/bin/python -m carconnectivity-mqtt /home/yourunixusername/carconnectivity/carconnectivity.json
+ExecStart=/home/yourunixusername/.local/bin/carconnectivity-mqtt /home/yourunixusername/carconnectivity/carconnectivity.json
 # Restart=on-failure
 
 [Install]


### PR DESCRIPTION
Running this on Raspbian GNU/Linux 11 (bullseye) caused issues with the hyphen in the *.service filename. I propose to omit the hyphen. 

Also calling I adjusted the ExecStart call (removed python interpreter call). 