### PR TITLE
fix: avoid logging raw binary MQTT payloads

### DIFF
--- a/src/carconnectivity_plugins/mqtt/mqtt_client.py
+++ b/src/carconnectivity_plugins/mqtt/mqtt_client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import logging
+import hashlib
 
 from enum import Enum
 from datetime import datetime, timedelta, tzinfo, timezone
@@ -350,6 +351,20 @@ class CarConnectivityMQTTClient(Client):  # pylint: disable=too-many-instance-at
             pass
         return super().disconnect(reasoncode, properties)
 
+    @staticmethod
+    def _format_value_for_log(value: Any) -> Any:
+        """Return a compact representation of values for debug logging.
+
+        Binary payloads, such as vehicle images, can be several megabytes large.
+        Logging their raw bytes makes debug logs hard to read and can fill log
+        storage quickly, so keep only metadata that is useful for diagnostics.
+        """
+        if isinstance(value, memoryview):
+            return f'<binary payload: {value.nbytes} bytes, sha256={hashlib.sha256(value).hexdigest()}>'
+        if isinstance(value, (bytes, bytearray)):
+            return f'<binary payload: {len(value)} bytes, sha256={hashlib.sha256(value).hexdigest()}>'
+        return value
+
     # pylint: disable-next=too-many-branches
     def _publish_element(self, element: Any) -> None:
         if element.enabled:
@@ -362,7 +377,9 @@ class CarConnectivityMQTTClient(Client):  # pylint: disable=too-many-instance-at
                     precision_tmp *= 10
                 value = round(value, precision_digits)
             converted_value = self.convert_value(value)
-            LOG.debug('%s%s, value changed: new value is: %s', self.prefix, element.get_absolute_path(), converted_value)
+            if LOG.isEnabledFor(logging.DEBUG):
+                LOG.debug('%s%s, value changed: new value is: %s',
+                          self.prefix, element.get_absolute_path(), self._format_value_for_log(converted_value))
             if self.topic_format == TopicFormat.SIMPLE:
                 topic: str = f'{self.prefix}{element.get_absolute_path()}'
                 if self.topic_filter_regex is None or not self.topic_filter_regex.match(topic):


### PR DESCRIPTION
## Summary
- format binary MQTT debug log values as compact metadata
- include payload size and SHA256 instead of dumping raw bytes

## Before

```
carconnectivity.plugins.mqtt:DEBUG:mqtt_client:carconnectivity-debug/garage/<vin>/images/car_picture, value changed: new value is: b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR...
```

## After
```log
carconnectivity.plugins.mqtt:DEBUG:mqtt_client:carconnectivity-debug/garage/<fin>/images/car_picture, value changed: new value is: <binary payload: 844845 bytes, sha256=78520f4577e064e2ff02b54621ca90e150e36029c57f78fc3072986ca8fc0b80>
```

## Testing
- tested locally with Docker Compose using a Skoda Kodiaq 2026 setup
- verified in compose logs that vehicle image payloads are logged as compact binary metadata
- confirmed 7 image payload log values shrink from ~35.3M characters to 724 characters in the collected logs